### PR TITLE
feat(publish-view): ListBoxRow's and similars are not focusable anymore

### DIFF
--- a/data/io.github.otaxhu.MQTTy.gschema.xml.in
+++ b/data/io.github.otaxhu.MQTTy.gschema.xml.in
@@ -15,6 +15,12 @@
     </key>
 
     <!--
+      TODO: This key is not being referenced in any part of the code,
+      MQTTy will get a "Workspace" feature very soon, in which all of
+      publish tabs and subscriptions will be saved to a serializable
+      file, that will be able to be loaded up to the app.
+    -->
+    <!--
       This is the human-readable type definition for this setting:
 
         type open-connections = []struct
@@ -23,9 +29,9 @@
             topic: String;
           }
      -->
-    <key name="connections" type="a(ss)">
+    <!-- <key name="connections" type="a(ss)">
       <default>[]</default>
       <summary>List of open connections</summary>
-    </key>
+    </key> -->
   </schema>
 </schemalist>

--- a/data/ui/key_value_row.blp
+++ b/data/ui/key_value_row.blp
@@ -16,6 +16,7 @@ using Gtk 4.0;
 
 template $MQTTyKeyValueRow: ListBoxRow {
   activatable: false;
+  focusable: false;
 
   Box {
     margin-start: 6;

--- a/data/ui/publish_view/publish_general_tab.blp
+++ b/data/ui/publish_view/publish_general_tab.blp
@@ -26,6 +26,7 @@ template $MQTTyPublishGeneralTab: Adw.Bin {
       Adw.ActionRow {
         title: _("MQTT Version");
         title-lines: 1;
+        focusable: false;
 
         [suffix]
         Box {
@@ -49,6 +50,7 @@ template $MQTTyPublishGeneralTab: Adw.Bin {
         title-lines: 1;
         subtitle: _("Quality of service");
         subtitle-lines: 1;
+        focusable: false;
 
         [suffix]
         Box {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod main_window;
 mod objects;
 mod pages;
 mod subclass;
+mod toast;
 mod widgets;
 
 use gettextrs::{gettext, LocaleCategory};

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 Oscar Pernia
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use adw::prelude::*;
+use gtk::glib;
+
+pub struct MQTTyToastBuilder {
+    inner: adw::builders::ToastBuilder,
+    title: Option<String>,
+    icon: Option<gtk::Image>,
+}
+
+impl MQTTyToastBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: adw::Toast::builder(),
+            title: None,
+            icon: None,
+        }
+    }
+
+    pub fn action_name(self, action_name: impl Into<glib::GString>) -> Self {
+        Self {
+            inner: self.inner.action_name(action_name),
+            ..self
+        }
+    }
+
+    pub fn action_target(self, action_target: &glib::Variant) -> Self {
+        Self {
+            inner: self.inner.action_target(action_target),
+            ..self
+        }
+    }
+
+    pub fn button_label(self, button_label: impl Into<glib::GString>) -> Self {
+        Self {
+            inner: self.inner.button_label(button_label),
+            ..self
+        }
+    }
+
+    pub fn priority(self, priority: adw::ToastPriority) -> Self {
+        Self {
+            inner: self.inner.priority(priority),
+            ..self
+        }
+    }
+
+    pub fn timeout(self, timeout: u32) -> Self {
+        Self {
+            inner: self.inner.timeout(timeout),
+            ..self
+        }
+    }
+
+    pub fn use_markup(self, use_markup: bool) -> Self {
+        Self {
+            inner: self.inner.use_markup(use_markup),
+            ..self
+        }
+    }
+
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn icon(mut self, icon: &gtk::Image) -> Self {
+        self.icon = Some(icon.clone());
+        self
+    }
+
+    pub fn build(self) -> adw::Toast {
+        if self.title.is_some() || self.icon.is_some() {
+            let b = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+            b.set_valign(gtk::Align::Center);
+            if let Some(icon) = self.icon {
+                b.append(&icon);
+            }
+            if let Some(title) = self.title {
+                let label = gtk::Label::new(Some(&title));
+                label.add_css_class("heading");
+                b.append(&label);
+            }
+            self.inner.custom_title(&b).build()
+        } else {
+            self.inner.build()
+        }
+    }
+}


### PR DESCRIPTION
This allows the users to just hit tab and go directly to the inner fields

feat(toasts): New MQTTyToastBuilder type, that adds the feature for adding an icon to the toast.