### PR TITLE
fix(win32): Quick fix, win32 app did not rendered properly

### DIFF
--- a/build-aux/msys2-build-portable.sh
+++ b/build-aux/msys2-build-portable.sh
@@ -138,7 +138,21 @@ You can download a copy of this software by visiting:
 
 https://github.com/otaxhu/MQTTy/releases
 
-To run MQTTy just execute the bin/MQTTy.exe file" > README.txt
+To run MQTTy just execute the bin/MQTTy.exe file
+
+# Troubleshooting
+
+- Bad performace:
+
+  If you are experiencing bad performance using MQTTy, you can enable hardware
+  acceleration by setting the 'GSK_RENDERER' environment variable to one of
+  'gl' or 'vulkan', this method will work only if you have updated graphics
+  drivers, and you are not using an old Intel iGPU.
+  
+  If none of those variables worked, you must make sure to unset the variable
+  to return to the previous state.
+  
+  For technical users, MQTTy uses 'GSK_RENDERER=cairo' as the default value" > README.txt
 
 OUTFILE=$(basename $OUTDIR).zip
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,14 @@ fn app_root_rel_path(path: &str) -> PathBuf {
 }
 
 fn main() -> glib::ExitCode {
+    // Prepare Windows-specific environment
+    #[cfg(target_os = "windows")]
+    {
+        if let Err(_) = std::env::var("GSK_RENDERER") {
+            std::env::set_var("GSK_RENDERER", "cairo");
+        }
+    }
+
     // Prepare i18n
     gettextrs::setlocale(LocaleCategory::LcAll, "");
     gettextrs::bindtextdomain(GETTEXT_PACKAGE, app_root_rel_path("share/locale"))


### PR DESCRIPTION
we are providing a reasonable default value `GSK_RENDERER=cairo` (software rendering by using Cairo)